### PR TITLE
Fix favicon path

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" type="image/x-icon" href="images/favicon.png">
+<link rel="icon" type="image/png" href="{{ '/images/favicon.png' | relative_url }}">


### PR DESCRIPTION
## Summary
- fix favicon path to use `relative_url` so it resolves correctly

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687634f32ca48322b6f7416f46b42dc2